### PR TITLE
Refactor navigation service for automatic view model injection

### DIFF
--- a/MauiAppCrud/MauiProgram.cs
+++ b/MauiAppCrud/MauiProgram.cs
@@ -61,9 +61,6 @@ namespace MauiAppCrud
             builder.Services.AddSingleton<ModalErrorHandler>();
             builder.Services.AddSingleton<INavigationService, NavigationService>();
 
-            builder.Services.AddTransientWithShellRoute<ClienteListPage, ClienteListViewModel>("clientes");
-            builder.Services.AddTransientWithShellRoute<ClienteDetailPage, ClienteDetailViewModel>("cliente");
-
             return builder.Build();
         }
     }

--- a/MauiAppCrud/Services/INavigationService.cs
+++ b/MauiAppCrud/Services/INavigationService.cs
@@ -1,3 +1,5 @@
+using Microsoft.Maui.Controls;
+
 namespace MauiAppCrud.Services
 {
     /// <summary>
@@ -11,5 +13,11 @@ namespace MauiAppCrud.Services
         /// <param name="route">Route string to navigate to.</param>
         /// <returns>A task representing the navigation.</returns>
         Task NavigateToAsync(string route);
+
+        /// <summary>
+        /// Initialize the view model for a page and inject navigation service.
+        /// </summary>
+        /// <param name="page">Page to initialize.</param>
+        void InitializeViewModel(Page page);
     }
 }

--- a/MauiAppCrud/Services/NavigationService.cs
+++ b/MauiAppCrud/Services/NavigationService.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+
 namespace MauiAppCrud.Services
 {
     /// <summary>
@@ -5,26 +11,81 @@ namespace MauiAppCrud.Services
     /// </summary>
     public class NavigationService : INavigationService
     {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IDictionary<string, Type> _routes = new Dictionary<string, Type>
+        {
+            ["clientes"] = typeof(ClienteListPage),
+            ["cliente"] = typeof(ClienteDetailPage)
+        };
+
+        public NavigationService(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
         /// <inheritdoc />
         public Task NavigateToAsync(string route)
         {
-            if (OperatingSystem.IsWindows())
+            if (route.StartsWith(".."))
             {
-                if (route.StartsWith(".."))
+                if (OperatingSystem.IsWindows())
                 {
                     var window = Application.Current?.Windows.LastOrDefault();
                     if (window != null && Application.Current?.Windows.Count > 1)
                         Application.Current?.CloseWindow(window);
-                    return Shell.Current.GoToAsync(route);
                 }
+                return Shell.Current.GoToAsync(route);
+            }
 
-                var page = Routing.GetOrCreateContent(route) as Page;
-                if (page is not null)
-                    Application.Current?.OpenWindow(new Window(page));
+            var baseRoute = route.Split('?')[0];
+            if (!_routes.TryGetValue(baseRoute, out var pageType))
+                return Shell.Current.GoToAsync(route);
+
+            var page = Activator.CreateInstance(pageType) as Page;
+            if (page is null)
+                return Task.CompletedTask;
+
+            InitializeViewModel(page);
+
+            if (page.BindingContext is IQueryAttributable queryable && route.Contains('?'))
+                queryable.ApplyQueryAttributes(ParseQuery(route));
+
+            if (OperatingSystem.IsWindows())
+            {
+                Application.Current?.OpenWindow(new Window(page));
                 return Task.CompletedTask;
             }
 
-            return Shell.Current.GoToAsync(route);
+            return Shell.Current.Navigation.PushAsync(page);
+        }
+
+        /// <inheritdoc />
+        public void InitializeViewModel(Page page)
+        {
+            var vmTypeName = page.GetType().FullName!
+                .Replace(".Pages.", ".ViewModels.")
+                .Replace("Page", "ViewModel");
+            var vmType = Type.GetType(vmTypeName);
+            if (vmType is null)
+                return;
+
+            var vm = ActivatorUtilities.CreateInstance(_serviceProvider, vmType);
+            if (vm is INavigationViewModel navigationViewModel)
+                navigationViewModel.Navigation = this;
+            page.BindingContext = vm;
+        }
+
+        private static IDictionary<string, object> ParseQuery(string route)
+        {
+            var result = new Dictionary<string, object>();
+            var query = route.Split('?', 2).Length > 1 ? route.Split('?', 2)[1] : string.Empty;
+            foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var kv = part.Split('=', 2);
+                if (kv.Length == 2)
+                    result[kv[0]] = Uri.UnescapeDataString(kv[1]);
+            }
+            return result;
         }
     }
 }

--- a/MauiAppCrud/ViewModels/Base/INavigationViewModel.cs
+++ b/MauiAppCrud/ViewModels/Base/INavigationViewModel.cs
@@ -8,6 +8,6 @@ namespace MauiAppCrud.ViewModels.Base
         /// <summary>
         /// Navigation service.
         /// </summary>
-        INavigationService Navigation { get; }
+        INavigationService Navigation { get; set; }
     }
 }

--- a/MauiAppCrud/ViewModels/ClienteDetailViewModel.cs
+++ b/MauiAppCrud/ViewModels/ClienteDetailViewModel.cs
@@ -10,7 +10,7 @@ namespace MauiAppCrud.ViewModels
     {
         private readonly ClienteRepository _clienteRepository;
         private readonly ModalErrorHandler _errorHandler;
-        public INavigationService Navigation { get; }
+        public INavigationService Navigation { get; set; }
 
         private bool _canDelete;
         public const string ClienteQueryKey = "cliente";
@@ -57,11 +57,10 @@ namespace MauiAppCrud.ViewModels
             SaveCommand.NotifyCanExecuteChanged();
         }
 
-        public ClienteDetailViewModel(ClienteRepository clienteRepository, ModalErrorHandler errorHandler, INavigationService navigation)
+        public ClienteDetailViewModel(ClienteRepository clienteRepository, ModalErrorHandler errorHandler)
         {
             _clienteRepository = clienteRepository;
             _errorHandler = errorHandler;
-            Navigation = navigation;
         }
 
         public void ApplyQueryAttributes(IDictionary<string, object> query)
@@ -77,7 +76,7 @@ namespace MauiAppCrud.ViewModels
 
                 if (_cliente is null)
                 {
-                    _errorHandler.HandleError(new Exception($"Cliente Id {id} n„o È v·lido."));
+                    _errorHandler.HandleError(new Exception($"Cliente Id {id} n√£o √© v√°lido."));
                     return;
                 }
 
@@ -115,32 +114,32 @@ namespace MauiAppCrud.ViewModels
         {
             if (string.IsNullOrWhiteSpace(Name))
             {
-                _errorHandler.HandleError(new Exception("O campo Nome n„o pode ser vazio."));
+                _errorHandler.HandleError(new Exception("O campo Nome n√£o pode ser vazio."));
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(LastName))
             {
-                _errorHandler.HandleError(new Exception("O campo Sobrenome n„o pode ser vazio."));
+                _errorHandler.HandleError(new Exception("O campo Sobrenome n√£o pode ser vazio."));
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(Age) || !int.TryParse(Age, out var age) || age <= 0)
             {
-                _errorHandler.HandleError(new Exception("A idade deve ser um n˙mero inteiro maior que zero."));
+                _errorHandler.HandleError(new Exception("A idade deve ser um n√∫mero inteiro maior que zero."));
                 return;
             }
             _cliente.Age = age;
 
             if (string.IsNullOrWhiteSpace(Address))
             {
-                _errorHandler.HandleError(new Exception("O campo EndereÁo n„o pode ser vazio."));
+                _errorHandler.HandleError(new Exception("O campo Endere√ßo n√£o pode ser vazio."));
                 return;
             }
 
             if (_cliente is null)
             {
-                _errorHandler.HandleError(new Exception("Cliente È nulo. N„o foi possÌvel salvar."));
+                _errorHandler.HandleError(new Exception("Cliente √© nulo. N√£o foi poss√≠vel salvar."));
                 return;
             }
 
@@ -162,15 +161,15 @@ namespace MauiAppCrud.ViewModels
             if (_cliente is null)
             {
                 _errorHandler.HandleError(
-                    new Exception("Cliente È nulo. N„o foi possÌvel deletar."));
+                    new Exception("Cliente √© nulo. N√£o foi poss√≠vel deletar."));
                 return;
             }
 
             bool confirmDelete = await Shell.Current.DisplayAlert(
-                "ConfirmaÁ„o",
+                "Confirma√ß√£o",
                 "Tem certeza que deseja excluir este cliente?",
                 "Sim",
-                "N„o");
+                "N√£o");
 
             if (!confirmDelete)
                 return;

--- a/MauiAppCrud/ViewModels/ClienteListViewModel.cs
+++ b/MauiAppCrud/ViewModels/ClienteListViewModel.cs
@@ -7,15 +7,14 @@ namespace MauiAppCrud.ViewModels
     public partial class ClienteListViewModel : ObservableObject, INavigationViewModel
     {
         private readonly ClienteRepository _clienteRepository;
-        public INavigationService Navigation { get; }
+        public INavigationService Navigation { get; set; }
 
         [ObservableProperty]
         private List<Cliente> _clientes = [];
 
-        public ClienteListViewModel(ClienteRepository projectRepository, INavigationService navigation)
+        public ClienteListViewModel(ClienteRepository projectRepository)
         {
             _clienteRepository = projectRepository;
-            Navigation = navigation;
         }
 
         [RelayCommand]

--- a/MauiAppCrud/Views/ClienteDetailPage.xaml.cs
+++ b/MauiAppCrud/Views/ClienteDetailPage.xaml.cs
@@ -1,13 +1,15 @@
 
+using Microsoft.Extensions.DependencyInjection;
+
 namespace MauiAppCrud.Pages
 {
     public partial class ClienteDetailPage : ContentPage
     {
         public ClienteDetailPage()
-        //public ClienteDetailPage(ClienteDetailViewModel model)
         {
             InitializeComponent();
-            //BindingContext = model;
+            var navigation = App.Current.Services.GetRequiredService<INavigationService>();
+            navigation.InitializeViewModel(this);
         }
     }
 }

--- a/MauiAppCrud/Views/ClienteListPage.xaml.cs
+++ b/MauiAppCrud/Views/ClienteListPage.xaml.cs
@@ -1,13 +1,14 @@
-using MauiAppCrud.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MauiAppCrud.Pages
 {
     public partial class ClienteListPage : ContentPage
     {
-        public ClienteListPage(ClienteListViewModel model)
+        public ClienteListPage()
         {
             InitializeComponent();
-            BindingContext = model;
+            var navigation = App.Current.Services.GetRequiredService<INavigationService>();
+            navigation.InitializeViewModel(this);
         }
     }
 }


### PR DESCRIPTION
## Summary
- inject navigation service into view models via NavigationService.InitializeViewModel
- remove page/view model registrations from MauiProgram
- add page constructors that request view model initialization from navigation service

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb897ff76c832ea4c6252bbfc3039a