### PR TITLE
Add asynchronous initialization for navigated view models

### DIFF
--- a/MauiAppCrud/Services/NavigationService.cs
+++ b/MauiAppCrud/Services/NavigationService.cs
@@ -24,7 +24,7 @@ namespace MauiAppCrud.Services
         }
 
         /// <inheritdoc />
-        public Task NavigateToAsync(string route)
+        public async Task NavigateToAsync(string route)
         {
             if (route.StartsWith(".."))
             {
@@ -34,34 +34,46 @@ namespace MauiAppCrud.Services
                     if (window != null && Application.Current?.Windows.Count > 1)
                         Application.Current?.CloseWindow(window);
                 }
-                return Shell.Current.GoToAsync(route);
+                await Shell.Current.GoToAsync(route);
+                return;
             }
 
             var baseRoute = route.Split('?')[0];
             if (!_routes.TryGetValue(baseRoute, out var pageType))
-                return Shell.Current.GoToAsync(route);
+            {
+                await Shell.Current.GoToAsync(route);
+                return;
+            }
 
             var page = Activator.CreateInstance(pageType) as Page;
             if (page is null)
-                return Task.CompletedTask;
+                return;
 
             InitializeViewModel(page);
 
-            if (page.BindingContext is IQueryAttributable queryable && route.Contains('?'))
-                queryable.ApplyQueryAttributes(ParseQuery(route));
+            var query = route.Contains('?') ? ParseQuery(route) : new Dictionary<string, object>();
+
+            if (page.BindingContext is IQueryAttributable queryable)
+                queryable.ApplyQueryAttributes(query);
+
+            if (page.BindingContext is INavigationViewModel navigationViewModel)
+                await navigationViewModel.InitializeAsync(query);
 
             if (OperatingSystem.IsWindows())
             {
                 Application.Current?.OpenWindow(new Window(page));
-                return Task.CompletedTask;
+                return;
             }
 
-            return Shell.Current.Navigation.PushAsync(page);
+            await Shell.Current.Navigation.PushAsync(page);
         }
 
         /// <inheritdoc />
         public void InitializeViewModel(Page page)
         {
+            if (page.BindingContext is not null)
+                return;
+
             if (page is IMauiView mauiView)
                 mauiView.InjectViewModel(_serviceProvider);
         }

--- a/MauiAppCrud/ViewModels/Base/INavigationViewModel.cs
+++ b/MauiAppCrud/ViewModels/Base/INavigationViewModel.cs
@@ -9,5 +9,11 @@ namespace MauiAppCrud.ViewModels.Base
         /// Navigation service.
         /// </summary>
         INavigationService Navigation { get; set; }
+
+        /// <summary>
+        /// Asynchronously initializes the view model when navigation occurs.
+        /// </summary>
+        /// <param name="parameters">Query parameters passed during navigation.</param>
+        Task InitializeAsync(IDictionary<string, object>? parameters);
     }
 }

--- a/MauiAppCrud/ViewModels/ClienteDetailViewModel.cs
+++ b/MauiAppCrud/ViewModels/ClienteDetailViewModel.cs
@@ -27,6 +27,7 @@ namespace MauiAppCrud.ViewModels
         [ObservableProperty] private string _age;
 
         private Cliente? _cliente;
+        private IDictionary<string, object> _queryParameters = new Dictionary<string, object>();
 
         public bool NameHasError => string.IsNullOrWhiteSpace(Name);
         public bool LastNameHasError => string.IsNullOrWhiteSpace(LastName);
@@ -65,7 +66,12 @@ namespace MauiAppCrud.ViewModels
 
         public void ApplyQueryAttributes(IDictionary<string, object> query)
         {
-            LoadClienteAsync(query).FireAndForgetSafeAsync(_errorHandler);
+            _queryParameters = query;
+        }
+
+        public async Task InitializeAsync(IDictionary<string, object>? parameters)
+        {
+            await LoadClienteAsync(parameters ?? _queryParameters);
         }
 
         private async Task LoadClienteAsync(IDictionary<string, object> query)

--- a/MauiAppCrud/ViewModels/ClienteListViewModel.cs
+++ b/MauiAppCrud/ViewModels/ClienteListViewModel.cs
@@ -17,8 +17,7 @@ namespace MauiAppCrud.ViewModels
             _clienteRepository = projectRepository;
         }
 
-        [RelayCommand]
-        private async Task Appearing()
+        public async Task InitializeAsync(IDictionary<string, object>? parameters)
         {
             Clientes = await _clienteRepository.ListAsync();
         }

--- a/MauiAppCrud/Views/Base/IMauiView.cs
+++ b/MauiAppCrud/Views/Base/IMauiView.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Controls;
 using MauiAppCrud.Services;
 using MauiAppCrud.ViewModels.Base;
+using MauiAppCrud.Utilities;
 
 namespace MauiAppCrud.Views.Base
 {
@@ -52,6 +53,9 @@ namespace MauiAppCrud.Views.Base
                 return;
 
             view.InjectViewModel(services);
+
+            if (view is Page page && page.BindingContext is INavigationViewModel navigationViewModel)
+                navigationViewModel.InitializeAsync(null).FireAndForgetSafeAsync();
         }
     }
 }

--- a/MauiAppCrud/Views/ClienteDetailPage.xaml.cs
+++ b/MauiAppCrud/Views/ClienteDetailPage.xaml.cs
@@ -8,7 +8,6 @@ namespace MauiAppCrud.Pages
         public ClienteDetailPage()
         {
             InitializeComponent();
-            this.InjectViewModel();
         }
     }
 }

--- a/MauiAppCrud/Views/ClienteListPage.xaml
+++ b/MauiAppCrud/Views/ClienteListPage.xaml
@@ -11,9 +11,6 @@
     x:DataType="vm:ClienteListViewModel">
 
 
-    <ContentPage.Behaviors>
-        <toolkit:EventToCommandBehavior Command="{Binding AppearingCommand}" EventName="Appearing" />
-    </ContentPage.Behaviors>
     <Grid>
         <Label
             FontAttributes="Italic"


### PR DESCRIPTION
## Summary
- invoke `InitializeAsync` during view model injection
- drop manual initialization from client list page
- rely on navigation service for detail page view model

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb93d50f44832e89eb1dd2648c26e6