### PR TITLE
Add functional tests for ClienteRepository

### DIFF
--- a/MauiAppCrud.Tests/MauiAppCrud.Tests.csproj
+++ b/MauiAppCrud.Tests/MauiAppCrud.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MauiAppCrud\MauiAppCrud.csproj" />
+  </ItemGroup>
+</Project>

--- a/MauiAppCrud.Tests/Repositories/ClienteRepositoryTests.cs
+++ b/MauiAppCrud.Tests/Repositories/ClienteRepositoryTests.cs
@@ -1,0 +1,50 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Maui.Storage;
+using MauiAppCrud.Data;
+using MauiAppCrud.Models;
+using Xunit;
+
+namespace MauiAppCrud.Tests.Repositories;
+
+public class ClienteRepositoryTests
+{
+    public ClienteRepositoryTests()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+
+        var fileSystem = new TestFileSystem(tempDir);
+        FileSystem.Current = fileSystem;
+    }
+
+    [Fact]
+    public async Task SaveAndRetrieveCliente()
+    {
+        var repo = new ClienteRepository(NullLogger<ClienteRepository>.Instance);
+        await repo.DropTableAsync();
+
+        var cliente = new Cliente
+        {
+            Name = "John",
+            LastName = "Doe",
+            Age = 30,
+            Address = "123 Street"
+        };
+
+        var id = await repo.SaveItemAsync(cliente);
+        Assert.True(id > 0);
+
+        var list = await repo.ListAsync();
+        Assert.Single(list);
+        Assert.Equal("John", list[0].Name);
+    }
+
+    private class TestFileSystem : IFileSystem
+    {
+        private readonly string _dir;
+        public TestFileSystem(string dir) => _dir = dir;
+        public string CacheDirectory => _dir;
+        public string AppDataDirectory => _dir;
+    }
+}

--- a/MauiAppCrud.sln
+++ b/MauiAppCrud.sln
@@ -1,22 +1,27 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.12.35527.113 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiAppCrud", "MauiAppCrud\MauiAppCrud.csproj", "{BA2DD7A4-7A80-44FA-8E45-E9691676D01C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiAppCrud", "MauiAppCrud\\MauiAppCrud.csproj", "{BA2DD7A4-7A80-44FA-8E45-E9691676D01C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiAppCrud.Tests", "MauiAppCrud.Tests\\MauiAppCrud.Tests.csproj", "{FE2D3142-CE1A-478C-916C-954B0407FD44}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{BA2DD7A4-7A80-44FA-8E45-E9691676D01C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BA2DD7A4-7A80-44FA-8E45-E9691676D01C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BA2DD7A4-7A80-44FA-8E45-E9691676D01C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BA2DD7A4-7A80-44FA-8E45-E9691676D01C}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {BA2DD7A4-7A80-44FA-8E45-E9691676D01C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {BA2DD7A4-7A80-44FA-8E45-E9691676D01C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {BA2DD7A4-7A80-44FA-8E45-E9691676D01C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {BA2DD7A4-7A80-44FA-8E45-E9691676D01C}.Release|Any CPU.Build.0 = Release|Any CPU
+        {FE2D3142-CE1A-478C-916C-954B0407FD44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {FE2D3142-CE1A-478C-916C-954B0407FD44}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {FE2D3142-CE1A-478C-916C-954B0407FD44}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {FE2D3142-CE1A-478C-916C-954B0407FD44}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add separate xUnit test project for ClienteRepository
- include functional test verifying save and retrieve operations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc17b70eac832e992abe771bb5b243